### PR TITLE
Fix: config generator overflowing when too long or too short

### DIFF
--- a/src/components/homePage/sideCards/configGeneratorCard.css
+++ b/src/components/homePage/sideCards/configGeneratorCard.css
@@ -2,4 +2,5 @@
   margin-top: 30px;
   border: #cccccc;
   background: #f5f5f5;
+  padding: 0 10px;
 }

--- a/src/components/homePage/sideCards/configGeneratorCard.js
+++ b/src/components/homePage/sideCards/configGeneratorCard.js
@@ -130,7 +130,7 @@ export default class ConfigGeneratorCard extends Component {
                     text={this.state.configBlock}
                     onCopy={() => message.success("复制成功", 1)}
                   >
-                    <span>
+                    <span style={{ width: "100%" }}>
                       <ConfigBlock
                         showConfigBlock={this.state.showConfigBlock}
                         configBlock={this.state.configBlock}


### PR DESCRIPTION
如图所示，根据配置长度不同，配置过长或过短，代码区域宽度异常

![image](https://user-images.githubusercontent.com/30528671/154830474-d0c2ac96-ed93-404d-89b8-73c64430e3cf.png)
![image](https://user-images.githubusercontent.com/30528671/154830481-92503093-7f9c-4216-8f64-e9f9bce44aca.png)
