### PR TITLE
Add bookworm version to Debian help page

### DIFF
--- a/src/components/docPage/doc/markdown/debian.md
+++ b/src/components/docPage/doc/markdown/debian.md
@@ -14,45 +14,6 @@ sudo cp /etc/apt/sources.list /etc/apt/sources.list_backup
 
 将上文中的配置文件替换为以下内容即可使用哈尔滨工业大学提供的镜像源服务，请根据你的 Debian 版本进行操作。
 
-+ buster
-
-  ```shell
-  # 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
-  # 目前还未提供debian-security，请注意添加
-  deb https://mirrors.hit.edu.cn/debian/ buster main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ buster main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ buster-updates main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ buster-updates main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ buster-backports main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ buster-backports main contrib non-free
-  ```
-
-+ stretch
-
-  ```shell
-  # 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
-  # 目前还未提供debian-security，请注意添加
-  deb https://mirrors.hit.edu.cn/debian/ stretch main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ stretch-updates main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch-updates main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ stretch-backports main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch-backports main contrib non-free
-  ```
-
-+ jessie
-
-  ```shell
-  # 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
-  # 目前还未提供debian-security，请注意添加
-  deb https://mirrors.hit.edu.cn/debian/ stretch main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ stretch-updates main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch-updates main contrib non-free
-  deb https://mirrors.hit.edu.cn/debian/ stretch-backports main contrib non-free
-  # deb-src https://mirrors.hit.edu.cn/debian/ stretch-backports main contrib non-free
-  ```
-
 + bullseye
 
   ```shell
@@ -64,5 +25,18 @@ sudo cp /etc/apt/sources.list /etc/apt/sources.list_backup
   # deb-src https://mirrors.hit.edu.cn/debian/ bullseye-updates main contrib non-free
   deb https://mirrors.hit.edu.cn/debian/ bullseye-backports main contrib non-free
   # deb-src https://mirrors.hit.edu.cn/debian/ bullseye-backports main contrib non-free
+  ```
+
++ bookworm
+
+  ```shell
+  # 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
+  # 目前还未提供debian-security，请注意添加
+  deb https://mirrors.hit.edu.cn/debian/ bookworm main contrib non-free
+  # deb-src https://mirrors.hit.edu.cn/debian/ bookworm main contrib non-free
+  deb https://mirrors.hit.edu.cn/debian/ bookworm-updates main contrib non-free
+  # deb-src https://mirrors.hit.edu.cn/debian/ bookworm-updates main contrib non-free
+  deb https://mirrors.hit.edu.cn/debian/ bookworm-backports main contrib non-free
+  # deb-src https://mirrors.hit.edu.cn/debian/ bookworm-backports main contrib non-free
   ```
 


### PR DESCRIPTION
Added Debian 12 help page and removed old, not supported versions.