### PR TITLE
fix: 追加 ubuntu/debian/alpine 配置生成缺失版本

### DIFF
--- a/public/static/config.json
+++ b/public/static/config.json
@@ -4,32 +4,78 @@
     "value": "ubuntu",
     "children": [
       {
-        "label": "22.04",
+        "label": "25.04 (plucky)",
+        "value": "plucky"
+      },
+      {
+        "label": "24.10 (oracular)",
+        "value": "oracular"
+      },
+      {
+        "label": "24.04 LTS (noble)",
+        "value": "noble"
+      },
+      {
+        "label": "22.04 LTS (jammy)",
         "value": "jammy"
       },
       {
-        "label": "21.10",
-        "value": "impish"
-      },
-      {
-        "label": "21.04",
-        "value": "hirsute"
-      },
-      {
-        "label": "20.04 LTS",
+        "label": "20.04 LTS (focal)",
         "value": "focal"
       },
       {
-        "label": "18.04 LTS",
+        "label": "18.04 LTS (bionic)",
         "value": "bionic"
       },
       {
-        "label": "16.04 LTS",
+        "label": "16.04 LTS (xenial)",
         "value": "xenial"
       },
       {
-        "label": "14.04 LTS",
+        "label": "14.04 LTS (trusty)",
         "value": "trusty"
+      },
+      {
+        "label": "25.10 (questing)",
+        "value": "questing"
+      },
+      {
+        "label": "devel (devel)",
+        "value": "devel"
+      }
+    ]
+  },
+  {
+    "label": "Ubuntu (deb822-style)",
+    "value": "ubuntu-deb822",
+    "children": [
+      {
+        "label": "25.04 (plucky)",
+        "value": "plucky"
+      },
+      {
+        "label": "24.10 (oracular)",
+        "value": "oracular"
+      },
+      {
+        "label": "24.04 LTS (noble)",
+        "value": "noble"
+      },
+      {
+        "label": "22.04 LTS (jammy)",
+        "value": "jammy"
+      },
+      {
+        "label": "20.04 LTS (focal)",
+        "value": "focal"
+      },
+      {
+        "label": "25.10 (questing)",
+        "value": "questing"
+      },
+      {
+        "label": "devel (devel)",
+        "value": "devel"
       }
     ]
   },
@@ -37,6 +83,10 @@
     "label": "Debian",
     "value": "debian",
     "children": [
+      {
+        "label": "12 bookworm",
+        "value": "bookworm"
+      },
       {
         "label": "11 bullseye",
         "value": "bullseye"
@@ -52,40 +102,112 @@
       {
         "label": "8 jessie",
         "value": "jessie"
+      },
+      {
+        "label": "13 trixie",
+        "value": "trixie"
       }
     ]
   },
-{
+  {
+    "label": "Debian-deb822-style",
+    "value": "debian-deb822",
+    "children": [
+      {
+        "label": "12 bookworm",
+        "value": "bookworm"
+      },
+      {
+        "label": "11 bullseye",
+        "value": "bullseye"
+      },
+      {
+        "label": "10 buster",
+        "value": "buster"
+      },
+      {
+        "label": "9 stretch",
+        "value": "stretch"
+      }
+    ]
+  },
+  {
     "label": "Ubuntu-ports",
     "value": "ubuntu-ports",
     "children": [
       {
-        "label": "22.04",
+        "label": "25.04 (plucky)",
+        "value": "plucky"
+      },
+      {
+        "label": "24.10 (oracular)",
+        "value": "oracular"
+      },
+      {
+        "label": "24.04 LTS (noble)",
+        "value": "noble"
+      },
+      {
+        "label": "22.04 LTS (jammy)",
         "value": "jammy"
       },
       {
-        "label": "21.10",
-        "value": "impish"
-      },
-      {
-        "label": "21.04",
-        "value": "hirsute"
-      },
-      {
-        "label": "20.04 LTS",
+        "label": "20.04 LTS (focal)",
         "value": "focal"
       },
       {
-        "label": "18.04 LTS",
+        "label": "18.04 LTS (bionic)",
         "value": "bionic"
       },
       {
-        "label": "16.04 LTS",
+        "label": "16.04 LTS (xenial)",
         "value": "xenial"
       },
       {
-        "label": "14.04 LTS",
+        "label": "14.04 LTS (trusty)",
         "value": "trusty"
+      },
+      {
+        "label": "25.10 (questing)",
+        "value": "questing"
+      },
+      {
+        "label": "devel (devel)",
+        "value": "devel"
+      }
+    ]
+  },
+  {
+    "label": "Ubuntu-ports (deb822-style)",
+    "value": "ubuntu-ports-deb822",
+    "children": [
+      {
+        "label": "25.04 (plucky)",
+        "value": "plucky"
+      },
+      {
+        "label": "24.10 (oracular)",
+        "value": "oracular"
+      },
+      {
+        "label": "24.04 LTS (noble)",
+        "value": "noble"
+      },
+      {
+        "label": "22.04 LTS (jammy)",
+        "value": "jammy"
+      },
+      {
+        "label": "20.04 LTS (focal)",
+        "value": "focal"
+      },
+      {
+        "label": "25.10 (questing)",
+        "value": "questing"
+      },
+      {
+        "label": "devel (devel)",
+        "value": "devel"
       }
     ]
   },
@@ -121,6 +243,34 @@
     "label": "Alpine",
     "value": "alpine",
     "children": [
+      {
+        "label": "V3.22",
+        "value": "3.22"
+      },
+      {
+        "label": "V3.21",
+        "value": "3.21"
+      },
+      {
+        "label": "V3.20",
+        "value": "3.20"
+      },
+      {
+        "label": "V3.19",
+        "value": "3.19"
+      },
+      {
+        "label": "V3.18",
+        "value": "3.18"
+      },
+      {
+        "label": "V3.17",
+        "value": "3.17"
+      },
+      {
+        "label": "V3.16",
+        "value": "3.16"
+      },
       {
         "label": "V3.15",
         "value": "3.15"

--- a/public/static/config.json
+++ b/public/static/config.json
@@ -120,14 +120,6 @@
       {
         "label": "11 bullseye",
         "value": "bullseye"
-      },
-      {
-        "label": "10 buster",
-        "value": "buster"
-      },
-      {
-        "label": "9 stretch",
-        "value": "stretch"
       }
     ]
   },

--- a/src/components/homePage/sideCards/configGeneratorCard.css
+++ b/src/components/homePage/sideCards/configGeneratorCard.css
@@ -3,4 +3,5 @@
   border: #cccccc;
   background: #f5f5f5;
   padding: 0 10px;
+  overflow-x: auto;
 }

--- a/src/components/homePage/sideCards/configGeneratorCard.js
+++ b/src/components/homePage/sideCards/configGeneratorCard.js
@@ -70,8 +70,17 @@ export default class ConfigGeneratorCard extends Component {
       case "ubuntu-ports":
         configBlock = buildUbuntuportsBlock(this.state.selectVersion);
         break;
+      case "ubuntu-deb822":
+        configBlock = buildUbuntuDeb822Block(this.state.selectVersion);
+        break;
+      case "ubuntu-ports-deb822":
+        configBlock = buildUbuntuPortsDeb822Block(this.state.selectVersion);
+        break;
       case "debian":
         configBlock = buildDebianBlock(this.state.selectVersion);
+        break;
+      case "debian-deb822":
+        configBlock = buildDebianDeb822Block(this.state.selectVersion);
         break;
       case "archlinux":
         configBlock = buildArchBlock();
@@ -233,6 +242,94 @@ function buildUbuntuportsBlock(version) {
 }
 
 /**
+ * 构建Ubuntu deb822格式软件源配置的文本块
+ *
+ * @param version 版本别名
+ * @returns {string} 返回Ubuntu deb822格式软件源配置的文本块
+ */
+function buildUbuntuDeb822Block(version) {
+  return (
+    "# 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释\n" +
+    "Types: deb\n" +
+    "URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "Suites: " + version + " " + version + "-updates " + version + "-backports\n" +
+    "Components: main universe restricted multiverse\n" +
+    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "# Suites: " + version + " " + version + "-updates " + version + "-backports\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "Types: deb\n" +
+    "URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "Suites: " + version + "-security\n" +
+    "Components: main universe restricted multiverse\n" +
+    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "# Suites: " + version + "-security\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# 预发布软件源，不建议启用\n" +
+    "# Types: deb\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "# Suites: " + version + "-proposed\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# 预发布软件源，不建议启用\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu/\n" +
+    "# Suites: " + version + "-proposed\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n"
+  );
+}
+
+/**
+ * 构建Ubuntu-ports deb822格式软件源配置的文本块
+ *
+ * @param version 版本别名
+ * @returns {string} 返回Ubuntu-ports deb822格式软件源配置的文本块
+ */
+function buildUbuntuPortsDeb822Block(version) {
+  return (
+    "# 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释\n" +
+    "Types: deb\n" +
+    "URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "Suites: " + version + " " + version + "-updates " + version + "-backports\n" +
+    "Components: main universe restricted multiverse\n" +
+    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "# Suites: " + version + " " + version + "-updates " + version + "-backports\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "Types: deb\n" +
+    "URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "Suites: " + version + "-security\n" +
+    "Components: main universe restricted multiverse\n" +
+    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "# Suites: " + version + "-security\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# 预发布软件源，不建议启用\n" +
+    "# Types: deb\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "# Suites: " + version + "-proposed\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n\n" +
+    "# 预发布软件源，不建议启用\n" +
+    "# Types: deb-src\n" +
+    "# URIs: http://mirrors.hit.edu.cn/ubuntu-ports/\n" +
+    "# Suites: " + version + "-proposed\n" +
+    "# Components: main universe restricted multiverse\n" +
+    "# Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n"
+  );
+}
+
+/**
  * 构建Alpine软件源配置的一行
  *
  * @param val 版本别名
@@ -286,16 +383,42 @@ function buildDebianLine(val, version) {
  */
 function buildDebianBlock(version) {
   return (
-    "# 目前还未提供debian-security，请注意添加\n" +
     buildDebianLine("deb", version) +
     buildDebianLine("# deb-src", version) +
     buildDebianLine("deb", version + "-updates") +
     buildDebianLine("# deb-src", version + "-updates") +
     buildDebianLine("deb", version + "-backports") +
-    buildDebianLine("# deb-src", version + "-backports")
+    buildDebianLine("# deb-src", version + "-backports") +
+    "\n# 目前还未提供 debian-security 镜像，请注意添加\n" +
+    "deb http://deb.debian.org/debian-security " + version + "-security main contrib non-free\n" +
+    "deb-src http://deb.debian.org/debian-security " + version + "-security main contrib non-free\n"
   );
 }
 
+function buildDebianDeb822Block(version) {
+  return ( // 12 才有 non-free-firmware，10 没有 backports
+    `Types: deb\n` +
+    `URIs: http://mirrors.hit.edu.cn/debian\n` +
+    `Suites: ${version} ${version}-updates ${version}-backports\n` +
+    `Components: main contrib non-free non-free-firmware\n` +
+    `Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\n` +
+    `# Types: deb-src\n` +
+    `# URIs: http://mirrors.hit.edu.cn/debian\n` +
+    `# Suites: ${version} ${version}-updates ${version}-backports\n` +
+    `# Components: main contrib non-free non-free-firmware\n` +
+    `# Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\n` +
+    `Types: deb\n` +
+    `URIs: http://security.debian.org/debian-security\n` +
+    `Suites: ${version}-security\n` +
+    `Components: main contrib non-free non-free-firmware\n` +
+    `Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\n` +
+    `# Types: deb-src\n` +
+    `# URIs: http://security.debian.org/debian-security\n` +
+    `# Suites: ${version}-security\n` +
+    `# Components: main contrib non-free non-free-firmware\n` +
+    `# Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg\n`
+  );
+}
 
 /**
  * 构建ArchLinux软件源配置的文本块


### PR DESCRIPTION
添加 debian 12/13，ubuntu 24.04/24.10/25.04，alpine 等新版内容
添加 debian/ubuntu deb822 格式

**目前配置方式不太方便支持不同版本不同细节，所以先补充了版本号**

---

TODO：计划重构一下配置生成器逻辑

**不同版本有一些细节不同**

比如 debian 12 的 non-free-firmware ，而 11 没有（这次 PR 没有做区分，参考 [TUNA Debian 帮助](https://mirrors.tuna.tsinghua.edu.cn/help/debian/)可以看到不同）

Debian 12：`deb https://mirrors.tuna.tsinghua.edu.cn/debian/ bookworm main contrib non-free non-free-firmware`
Debian 11：`deb https://mirrors.tuna.tsinghua.edu.cn/debian/ bullseye main contrib non-free`

**增加可选项，而非现在每个版本固定配置**

如 使用 HTTPS、源码源、非自由内容 等（如 https://help.mirrors.cernet.edu.cn/debian/ https://mirrors.tuna.tsinghua.edu.cn/help/debian/ ）

**更利于维护**

现在的配置方式（buildLine + buildBlock）也不是很好维护

**与帮助页同步**

如 [HIT Debian 帮助](https://mirrors.hit.edu.cn/#/doc/debian) 是列举出来的，而且代号顺序也不直观